### PR TITLE
chore: release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project does not adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) until v1.0.0.
 
+## [1.0.1](https://github.com/oxc-project/oxc-index-vec/compare/v1.0.0...v1.0.1) - 2024-12-01
+
+### Fixed
+
+- clippy
+
+### Other
+
+- remove allowed clippy rules
+- update repo
+- add default features
+
 ## [0.34.0] - 2024-10-26
 
 ### Refactor

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "oxc_index"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "rayon",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_index"
-version = "1.0.0"
+version = "1.0.1"
 publish = true
 authors = ["Boshen <boshenc@gmail.com>"]
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `oxc_index`: 1.0.0 -> 1.0.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.1](https://github.com/oxc-project/oxc-index-vec/compare/v1.0.0...v1.0.1) - 2024-12-01

### Fixed

- clippy

### Other

- remove allowed clippy rules
- update repo
- add default features
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).