### PR TITLE
chore: release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project does not adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) until v1.0.0.
 
+## [2.0.0](https://github.com/oxc-project/oxc-index-vec/compare/v1.0.1...v2.0.0) - 2024-12-09
+
+### Other
+
+- use "serde" feature
+- *(deps)* update dependency rust to v1.83.0 (#2)
+- add README
+
 ## [1.0.1](https://github.com/oxc-project/oxc-index-vec/compare/v1.0.0...v1.0.1) - 2024-12-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "oxc_index"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "rayon",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_index"
-version = "1.0.1"
+version = "2.0.0"
 publish = true
 authors = ["Boshen <boshenc@gmail.com>"]
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `oxc_index`: 1.0.1 -> 2.0.0 (⚠️ API breaking changes)

### ⚠️ `oxc_index` breaking changes

```
--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/feature_missing.ron

Failed in:
  feature serialize in the package's Cargo.toml
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.0](https://github.com/oxc-project/oxc-index-vec/compare/v1.0.1...v2.0.0) - 2024-12-09

### Other

- use "serde" feature
- *(deps)* update dependency rust to v1.83.0 (#2)
- add README
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).