### PR TITLE
perf: reduce bounds checks in IndexVec::push()

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -590,9 +590,16 @@ macro_rules! __define_index_type_inner {
         }
 
         impl $crate::Idx for $type {
+            const MAX: usize = Self::MAX_INDEX;
+
             #[inline]
             fn from_usize(value: usize) -> Self {
                 Self::from(value)
+            }
+
+            #[inline]
+            unsafe fn from_usize_unchecked(value: usize) -> Self {
+                Self::from_usize_unchecked(value)
             }
 
             #[inline]


### PR DESCRIPTION
## Summary

This PR implements the optimization described in #109 to reduce bounds checks in `IndexVec::push()` by moving them to the cold growth path.

## Changes

### 1. Extended the `Idx` trait
- Added `MAX` associated constant representing the maximum valid index value
- Added unsafe `from_usize_unchecked()` method for creating indices without bounds checking

### 2. Updated macro-generated index types
- Implemented the new `MAX` constant as `Self::MAX_INDEX`
- Connected `from_usize_unchecked()` to the existing implementation

### 3. Added capacity management to `IndexVec`
- Added `MIN_CAPACITY` constant based on type size for efficient small vector growth
- Added `max_capacity()` function limited by `I::MAX` and memory constraints
- Added `grow_capacity()` and `grow()` helper functions marked as `#[cold]` and `#[inline(never)]`

### 4. Optimized the `push()` method
- **Fast path**: When capacity is available and within bounds, uses `unsafe { I::from_usize_unchecked(len) }`
- **Slow path**: Marked as cold, handles capacity growth with proper bounds checking
- Ensures capacity never exceeds `I::MAX`

## Performance Benefits

- Bounds checking moved to the cold growth path, reducing overhead on the hot path
- The `push()` function is more likely to be inlined due to reduced complexity on the fast path
- All safety guarantees maintained through careful use of unsafe code
- Particularly benefits types like `AstNodeId`, `ScopeId`, `SymbolId`, and `ReferenceId` which wrap `NonMaxU32`

## Testing

- Added comprehensive tests for the new functionality
- All existing tests continue to pass
- Verified that maximum capacity limits are respected
- Tested that bounds checking still functions when needed

Closes #109

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>