### PR TITLE
chore: release v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0](https://github.com/oxc-project/oxc-index-vec/compare/v3.1.0...v4.0.0) - 2025-09-30
+
+### Added
+
+- add const support to methods where possible ([#87](https://github.com/oxc-project/oxc-index-vec/pull/87))
+- add NonMaxU32 support via define_nonmax_index_type! macro ([#86](https://github.com/oxc-project/oxc-index-vec/pull/86))
+
+### Fixed
+
+- reorder attributes in define_nonmax_index_type! for proc macro compatibility
+
+### Other
+
+- cargo fmt
+- make serde and nonmax optional features
+- make nonmax support always available and use crate's own nonmax
+- make serde support always available and use crate's own serde
+- add documentation to all public methods to fix missing_docs warnings
+- remove backward compatibility alias for define_nonmax_index_type!
+- rename define_nonmax_index_type! to define_nonmax_u32_index_type!
+- apply tuple struct pattern to define_index_type! macro
+- remove #[repr(transparent)] from define_nonmax_index_type!
+- change define_nonmax_index_type! to use tuple struct pattern
+- document custom attribute support in define_nonmax_index_type!
+- remove bounds check from IndexVec::push ([#84](https://github.com/oxc-project/oxc-index-vec/pull/84))
+
 ## [3.1.0](https://github.com/oxc-project/oxc-index-vec/compare/v3.0.0...v3.1.0) - 2025-09-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
 
 [[package]]
 name = "oxc_index"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "nonmax",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_index"
-version = "3.1.0"
+version = "4.0.0"
 publish = true
 authors = ["Boshen <boshenc@gmail.com>"]
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `oxc_index`: 3.1.0 -> 4.0.0 (⚠ API breaking changes)

### ⚠ `oxc_index` breaking changes

```text
--- failure trait_associated_const_added: non-sealed trait added associated constant without default value ---

Description:
A non-sealed trait has gained an associated constant without a default value, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/trait_associated_const_added.ron

Failed in:
  trait constant oxc_index::Idx::MAX in file /tmp/.tmpgQzCch/oxc-index-vec/src/lib.rs:200

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/trait_method_added.ron

Failed in:
  trait method oxc_index::Idx::from_usize_unchecked in file /tmp/.tmpgQzCch/oxc-index-vec/src/lib.rs:206
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [4.0.0](https://github.com/oxc-project/oxc-index-vec/compare/v3.1.0...v4.0.0) - 2025-09-30

### Added

- add const support to methods where possible ([#87](https://github.com/oxc-project/oxc-index-vec/pull/87))
- add NonMaxU32 support via define_nonmax_index_type! macro ([#86](https://github.com/oxc-project/oxc-index-vec/pull/86))

### Fixed

- reorder attributes in define_nonmax_index_type! for proc macro compatibility

### Other

- cargo fmt
- make serde and nonmax optional features
- make nonmax support always available and use crate's own nonmax
- make serde support always available and use crate's own serde
- add documentation to all public methods to fix missing_docs warnings
- remove backward compatibility alias for define_nonmax_index_type!
- rename define_nonmax_index_type! to define_nonmax_u32_index_type!
- apply tuple struct pattern to define_index_type! macro
- remove #[repr(transparent)] from define_nonmax_index_type!
- change define_nonmax_index_type! to use tuple struct pattern
- document custom attribute support in define_nonmax_index_type!
- remove bounds check from IndexVec::push ([#84](https://github.com/oxc-project/oxc-index-vec/pull/84))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).