### PR TITLE
chore: release v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.0](https://github.com/oxc-project/oxc-index-vec/compare/v4.0.0...v4.1.0) - 2025-10-04
+
+### Added
+
+- improve Debug output for index types ([#92](https://github.com/oxc-project/oxc-index-vec/pull/92))
+
+### Other
+
+- update README with new features and usage examples
+
 ## [4.0.0](https://github.com/oxc-project/oxc-index-vec/compare/v3.1.0...v4.0.0) - 2025-09-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
 
 [[package]]
 name = "oxc_index"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "nonmax",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_index"
-version = "4.0.0"
+version = "4.1.0"
 publish = true
 authors = ["Boshen <boshenc@gmail.com>"]
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `oxc_index`: 4.0.0 -> 4.1.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [4.1.0](https://github.com/oxc-project/oxc-index-vec/compare/v4.0.0...v4.1.0) - 2025-10-04

### Added

- improve Debug output for index types ([#92](https://github.com/oxc-project/oxc-index-vec/pull/92))

### Other

- update README with new features and usage examples
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).