### PR TITLE
feat: improve Debug output for index types

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -328,7 +328,7 @@ macro_rules! define_nonmax_u32_index_type {
 
         impl core::fmt::Debug for $type {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                write!(f, "{}", self.index())
+                write!(f, "{}({})", stringify!($type), self.index())
             }
         }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -611,9 +611,9 @@ fn test_nonmax_with_attrs() {
     // Test that custom attributes work with define_nonmax_u32_index_type!
     let idx = IdxNonMaxWithAttrs::new(42);
 
-    // Verify Debug derive works
+    // Verify Debug impl works
     let debug_str = format!("{:?}", idx);
-    assert_eq!(debug_str, "42");
+    assert_eq!(debug_str, "IdxNonMaxWithAttrs(42)");
 
     // Verify all standard functionality works
     assert_eq!(idx.index(), 42);


### PR DESCRIPTION
## Summary

Changes the `Debug` output format for types created with `define_nonmax_u32_index_type!` from just the raw number (e.g., `42`) to include the type name (e.g., `ScopeId(42)`).

This makes debug output and error messages much clearer, especially when displaying multiple different index types together.

## Example

For example, in semantic analysis snapshots, scope and symbol IDs are now clearly distinguished:

**Before:**
```
Scope children mismatch:
after transform: 0: [1]
rebuilt        : 0: [1, 2, 4]
```

**After:**
```
Scope children mismatch:
after transform: ScopeId(0): [ScopeId(1)]
rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
```

## Changes

- Updated `Debug` impl in `define_nonmax_u32_index_type!` macro to use `stringify!($type)` to include the type name
- Updated test to expect the new format

🤖 Generated with [Claude Code](https://claude.com/claude-code)