### PR TITLE
chore: release v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.0](https://github.com/oxc-project/oxc-index-vec/compare/v4.1.0...v5.0.0) - 2026-06-05
+
+### Fixed
+
+- [**breaking**] `define_nonmax_u32_index_type!` macro make `from_usize_unchecked` and `from_raw_unchecked` unsafe methods ([#179](https://github.com/oxc-project/oxc-index-vec/pull/179))
+
+### Other
+
+- capitalize `SAFETY` comments ([#180](https://github.com/oxc-project/oxc-index-vec/pull/180))
+- *(deps)* update rust crate rayon to v1.12.0 ([#164](https://github.com/oxc-project/oxc-index-vec/pull/164))
+- apply cargo shear --fix ([#151](https://github.com/oxc-project/oxc-index-vec/pull/151))
+
 ## [4.1.0](https://github.com/oxc-project/oxc-index-vec/compare/v4.0.0...v4.1.0) - 2025-10-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
 
 [[package]]
 name = "oxc_index"
-version = "4.1.0"
+version = "5.0.0"
 dependencies = [
  "nonmax",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc_index"
-version = "4.1.0"
+version = "5.0.0"
 publish = true
 authors = ["Boshen <boshenc@gmail.com>"]
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `oxc_index`: 4.1.0 -> 5.0.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [5.0.0](https://github.com/oxc-project/oxc-index-vec/compare/v4.1.0...v5.0.0) - 2026-06-05

### Fixed

- [**breaking**] `define_nonmax_u32_index_type!` macro make `from_usize_unchecked` and `from_raw_unchecked` unsafe methods ([#179](https://github.com/oxc-project/oxc-index-vec/pull/179))

### Other

- capitalize `SAFETY` comments ([#180](https://github.com/oxc-project/oxc-index-vec/pull/180))
- *(deps)* update rust crate rayon to v1.12.0 ([#164](https://github.com/oxc-project/oxc-index-vec/pull/164))
- apply cargo shear --fix ([#151](https://github.com/oxc-project/oxc-index-vec/pull/151))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).