### PR TITLE
ci: change ubuntu-slim to ubuntu-latest

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,6 +19,6 @@ concurrency:
 jobs:
   security:
     name: Security Analysis
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - uses: oxc-project/security-action@77e230508eccbb400b23746dab6c573a8ea7483e # v1.0.5


### PR DESCRIPTION
## Summary
- Switch the security workflow runner from `ubuntu-slim` to `ubuntu-latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)