### PR TITLE
fix!: `define_nonmax_u32_index_type!` macro make `from_usize_unchecked` and `from_raw_unchecked` unsafe methods

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -277,9 +277,9 @@ macro_rules! define_nonmax_u32_index_type {
             /// Create an index from a `usize` without bounds checking.
             ///
             /// # Safety
-            /// The caller must ensure `value <= MAX_INDEX`.
+            /// The caller must ensure `value < (u32::MAX as usize)`.
             #[inline(always)]
-            $v const fn from_usize_unchecked(value: usize) -> Self {
+            $v const unsafe fn from_usize_unchecked(value: usize) -> Self {
                 Self(unsafe { $crate::nonmax::NonMaxU32::new_unchecked(value as u32) })
             }
 
@@ -288,7 +288,7 @@ macro_rules! define_nonmax_u32_index_type {
             /// # Safety
             /// The caller must ensure the value is not `u32::MAX`.
             #[inline(always)]
-            $v const fn from_raw_unchecked(raw: u32) -> Self {
+            $v const unsafe fn from_raw_unchecked(raw: u32) -> Self {
                 Self(unsafe { $crate::nonmax::NonMaxU32::new_unchecked(raw) })
             }
 
@@ -449,7 +449,7 @@ macro_rules! define_nonmax_u32_index_type {
 
             #[inline]
             unsafe fn from_usize_unchecked(idx: usize) -> Self {
-                Self::from_usize_unchecked(idx)
+                unsafe { Self::from_usize_unchecked(idx) }
             }
 
             #[inline]


### PR DESCRIPTION
Fix for https://github.com/oxc-project/oxc/issues/22592.

`define_nonmax_u32_index_type!` macro creates a type with `from_usize_unchecked` and `from_raw_unchecked` methods. These methods contain unsafe code with unchecked invariants, but were not unsafe methods themselves.

It was trivial to trigger UB from safe code:

```rs
define_nonmax_u32_index_type! {
    pub struct MyIndex;
}

let oops = MyIndex::from_usize_unchecked(u32::MAX as usize);
let oh_no = MyIndex::from_raw_unchecked(u32::MAX);
```

Fix this unsoundness by making both methods `unsafe`.