### PR TITLE
docs: capitalize `SAFETY` comments

### DIFF
--- a/src/idxslice.rs
+++ b/src/idxslice.rs
@@ -603,7 +603,7 @@ impl<I: Idx, T> IndexSlice<I, [T]> {
 
     /// Create a IdxSlice from its pointer and length.
     ///
-    /// # Safety
+    /// # SAFETY
     ///
     /// This is equivalent to `core::slice::from_raw_parts` and has the same
     /// safety caveats.
@@ -614,7 +614,7 @@ impl<I: Idx, T> IndexSlice<I, [T]> {
 
     /// Create a mutable IdxSlice from its pointer and length.
     ///
-    /// # Safety
+    /// # SAFETY
     ///
     /// This is equivalent to `core::slice::from_raw_parts_mut` and has the same
     /// safety caveats.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@ pub trait Idx: Copy + 'static + Ord + Debug + Hash {
 
     /// Construct an index from a `usize` without bounds checking.
     ///
-    /// # Safety
+    /// # SAFETY
     /// The caller must ensure that `idx <= Self::MAX`.
     unsafe fn from_usize_unchecked(idx: usize) -> Self;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -276,7 +276,7 @@ macro_rules! define_nonmax_u32_index_type {
 
             /// Create an index from a `usize` without bounds checking.
             ///
-            /// # Safety
+            /// # SAFETY
             /// The caller must ensure `value < (u32::MAX as usize)`.
             #[inline(always)]
             $v const unsafe fn from_usize_unchecked(value: usize) -> Self {
@@ -285,7 +285,7 @@ macro_rules! define_nonmax_u32_index_type {
 
             /// Create an index from a raw `u32` without bounds checking.
             ///
-            /// # Safety
+            /// # SAFETY
             /// The caller must ensure the value is not `u32::MAX`.
             #[inline(always)]
             $v const unsafe fn from_raw_unchecked(raw: u32) -> Self {


### PR DESCRIPTION
Cosmetic change only. Capitalize safety doc comments, following the convention we use in other Oxc crates.